### PR TITLE
fix: ignore semantic/ folder in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+semantic/*/** linguist-generated=true


### PR DESCRIPTION
This commit tells Linguist to ignore the `semantic/` folder to prevent inflated language stats