### PR TITLE
fix: update package.json to add missing files from webpack chunks

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 			"dist/js/main/**/*.js",
 			"dist/js/universal/**/*.js",
 			"dist/views/**/*",
-			"dist/renderer.bundle.js",
+			"dist/*.js",
 			"src/renderer/css/*.css",
 			"src/renderer/js/**/*.js",
 			"semantic/dist/*.js",


### PR DESCRIPTION
Changed the build configuration for electron-builder to include chunks generated by webpack. Previously, webpack only generated one chunk named renderer.bundle.js but the code has been split up into multiple chunks to improve performance.