### PR TITLE
Fix: macOS build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Package application with electron-builder
         run: npm run pack
       - name: Publish artificats
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         with:
           name: macos-build
           path: dist/mac/

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Package application with electron-builder
         run: npm run pack
       - name: Publish artificats
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v1
         with:
           name: macos
           path: dist/mac/


### PR DESCRIPTION
Revert `actions/upload-artifact` bump to v2 to fix macOS build workflow in GitHub Actions.

Fixes #315 